### PR TITLE
fix reading config file string[] options

### DIFF
--- a/source/args.d
+++ b/source/args.d
@@ -206,7 +206,7 @@ void writeConfigToFile(Opt)(string filename, ref Opt opt) {
 }
 
 void writeConfigToFileImpl(Opt,LTW)(ref Opt opt, ref LTW ltw, string prefix) {
-	import std.traits : hasUDA, getUDAs, Unqual, isArray, isSomeString, isConvertibleToString;
+	import std.traits : hasUDA, getUDAs, Unqual, isArray, isSomeString, isNarrowString;
 	import std.format : formattedWrite;	
 	import std.array;
 	foreach(mem; __traits(allMembers, Opt)) {
@@ -221,8 +221,8 @@ void writeConfigToFileImpl(Opt,LTW)(ref Opt opt, ref LTW ltw, string prefix) {
 				printHelpMessageConfig!(typeof(__traits(getMember, Opt, mem)))(
 						ltw, optMemArg
 					);
-				alias ArgType = Unqual!(typeof(__traits(getMember, opt, mem)));
-				static if(isArray!(ArgType) && isSomeString!(ArgType) && isConvertibleToString!(ArgType)) {
+				string[] testArr;
+				static if (is(typeof(testArr) == typeof(__traits(getMember, opt, mem)))) {
 					string[] optArr = __traits(getMember, opt, mem);
 					string def = optArr[0];
 					// special case: string[]
@@ -1081,4 +1081,44 @@ unittest {
 	auto args = ["funcname", "--a", "10", "--en.en2.e", "yes"];
 	Options opt;
 	assertThrown!Exception(parseArgs(opt, args));
+}
+
+unittest {
+	import std.stdio;
+
+	static struct Options {
+		@Arg('s') string[] strings = ["arg1"];
+	}
+
+	Options opt;
+
+	ref Options configWriteable() {
+		return opt;
+	}
+
+	ref const(Options) config() {
+		return opt;
+	}
+
+	// test command line arguments
+	auto args = ["progname", "-s", "arg2", "--strings", "arg3"];
+	assert(!parseArgsWithConfigFile(opt, args));
+
+	const string[] strArr = config().strings;
+	assert(strArr[0] == "arg1");
+	assert(strArr[1] == "arg2");
+	assert(strArr[2] == "arg3");
+
+	// test config file parsing
+	Options opt2;
+	writeConfigToFile("stringTest.conf", opt2);
+	auto data = parseArgsConfigFile("stringTest.conf");
+	parseConfigFile(opt2, data);
+
+	// there should be two equal elements (arg1):
+	// 1. the one set as default in the declaration of struct Options
+	// 2. the one which has been read from the config file written in 1.
+	assert(opt2.strings.length == 2);
+	assert(opt2.strings[0] == "arg1");
+	assert(opt2.strings[1] == "arg1");
 }

--- a/source/args.d
+++ b/source/args.d
@@ -206,7 +206,7 @@ void writeConfigToFile(Opt)(string filename, ref Opt opt) {
 }
 
 void writeConfigToFileImpl(Opt,LTW)(ref Opt opt, ref LTW ltw, string prefix) {
-	import std.traits : hasUDA, getUDAs, Unqual, isArray, isSomeString, isNarrowString;
+	import std.traits : hasUDA, getUDAs;
 	import std.format : formattedWrite;	
 	import std.array;
 	foreach(mem; __traits(allMembers, Opt)) {
@@ -1084,7 +1084,6 @@ unittest {
 }
 
 unittest {
-	import std.stdio;
 
 	static struct Options {
 		@Arg('s') string[] strings = ["arg1"];

--- a/source/args.d
+++ b/source/args.d
@@ -1109,10 +1109,14 @@ unittest {
 	assert(strArr[2] == "arg3");
 
 	// test config file parsing
+	import std.file : remove;
+
 	Options opt2;
 	writeConfigToFile("stringTest.conf", opt2);
 	auto data = parseArgsConfigFile("stringTest.conf");
 	parseConfigFile(opt2, data);
+	remove("stringTest.conf");
+
 
 	// there should be two equal elements (arg1):
 	// 1. the one set as default in the declaration of struct Options

--- a/source/args.d
+++ b/source/args.d
@@ -206,7 +206,7 @@ void writeConfigToFile(Opt)(string filename, ref Opt opt) {
 }
 
 void writeConfigToFileImpl(Opt,LTW)(ref Opt opt, ref LTW ltw, string prefix) {
-	import std.traits : hasUDA, getUDAs, Unqual, isArray, isSomeString;
+	import std.traits : hasUDA, getUDAs, Unqual, isArray, isSomeString, isConvertibleToString;
 	import std.format : formattedWrite;	
 	import std.array;
 	foreach(mem; __traits(allMembers, Opt)) {
@@ -222,7 +222,7 @@ void writeConfigToFileImpl(Opt,LTW)(ref Opt opt, ref LTW ltw, string prefix) {
 						ltw, optMemArg
 					);
 				alias ArgType = Unqual!(typeof(__traits(getMember, opt, mem)));
-				static if(isArray!(ArgType) && !isSomeString!(ArgType)) {
+				static if(isArray!(ArgType) && isSomeString!(ArgType) && isConvertibleToString!(ArgType)) {
 					string[] optArr = __traits(getMember, opt, mem);
 					string def = optArr[0];
 					// special case: string[]


### PR DESCRIPTION
Hi, I'm using your library for a project which requires config file parsing, and I noticed an error with the '--genConfig' options that formatted string[] type arguments this way in the config file:

arg = "["default opt"]"

This causes parsing to fail, returning:
 ["opt"]  as a string inside the string[] argument (while it should be "opt").

I propose this fix:
Instead of generating a config file in which string[] options are formatted in square brackets, I'd print them with this format:

arg = "default opt"

Since I noticed that for array arguments, your library allows multiple entries as such:

arg = "opt1"
arg = "opt2"

Which are automatically added as members of the array. 

Keep up the great work man, you library is great!